### PR TITLE
Navigatie van instellingen terug naar beginscherm en StartSpel gefixed.

### DIFF
--- a/Prototype_Game Interaction/Instellingen.xaml.cs
+++ b/Prototype_Game Interaction/Instellingen.xaml.cs
@@ -32,7 +32,7 @@ namespace Prototype_Game_Interaction
                 {
                     StartSpel StartSpel = new StartSpel();
                     StartSpel.Visibility = Visibility.Visible;
-                    this.Visibility = Visibility.Hidden; 
+                     
                 }
                 else
                 {
@@ -40,8 +40,8 @@ namespace Prototype_Game_Interaction
 
                     MainWindow mainWindow = new MainWindow();
                     mainWindow.Visibility = Visibility.Visible;
-                    this.Visibility = Visibility.Hidden;
                 }
+                this.Visibility = Visibility.Hidden;
             }    
         }
 

--- a/Prototype_Game Interaction/StartSpel.xaml.cs
+++ b/Prototype_Game Interaction/StartSpel.xaml.cs
@@ -12,7 +12,6 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
-using Prototype_Game_Interaction;
 
 namespace Prototype_Game_Interaction
 {
@@ -43,8 +42,6 @@ namespace Prototype_Game_Interaction
         }
         private void InstellingenClick(object sender, RoutedEventArgs e)
         {
-            SharedData.CurrentScreen = "Instellingen";
-
             Instellingen instellingen = new Instellingen();
             instellingen.Visibility = Visibility.Visible;
             this.Visibility = Visibility.Hidden;


### PR DESCRIPTION
Van beginscherm naar instellingen en weer terug naar beginscherm ging goed. Van StartSpel naar instellingen en weer terug naar StartSpel, ging niet goed. Hij ging terug naar het beginscherm. Dit is nu opgelost.